### PR TITLE
CLI options that correspond directly to API options

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Usage: nwbuild [options] [path]
 Options:
   -p, --platforms      Platforms to build, comma-sperated, can be: win,osx,linux32,linux64   [default: "osx,win"]
   -v, --version        The nw version, eg. 0.8.4                                             [default: "latest"]
-  -r, --run            Runs node-webkit for the current platform                            [default: false]  
+  -r, --run            Runs node-webkit for the current platform                             [default: false]  
   -o, --buildDir       The build folder                                                      [default: "./build"]
   -f, --forceDownload  Force download of node-webkit                                         [default: false]
   --quiet              Disables logging                                                      [default: false]
@@ -60,7 +60,7 @@ nw.build().then(function () {
 // And supports callbacks
 nw.build(function(err) {
     if(err) console.log(err);
-})
+});
 
 ```
 
@@ -109,7 +109,7 @@ Default value: `./cache`
 
 This is where the cached node-webkit downloads are
 
-#### options.buildType
+#### options.buildNamingScheme (depricating options.buildType)
 Type: `String` or `function`
 Default value: `default`  
 

--- a/bin/nwbuild
+++ b/bin/nwbuild
@@ -3,7 +3,7 @@ var optimist = require('optimist');
 var updateNotifier = require('update-notifier');
 var NwBuilder = require('./../lib');
 var path = require('path');
-var detectCurrentPlatform = require('../lib/detectCurrentPlatform.js')
+var detectCurrentPlatform = require('../lib/detectCurrentPlatform.js');
 
 var argv = optimist
     .usage('Usage: nwbuild [options] [path]')
@@ -31,6 +31,39 @@ var argv = optimist
     .default('f', false)
     .describe('f', 'Force download of node-webkit')
     .boolean('f')
+
+
+
+
+    .describe('appName', 'The Name of your node-webkit app')
+    .default('appName', false)
+    
+    .describe('appVersion', 'The version of your node-webkit app')
+    .default('appVersion', false)
+    
+    .describe('cacheDir', 'The directory to store cached node-webkit downloads')
+    .default('cacheDir', false)
+    
+    .describe('buildNamingScheme', 'How you want to name your builds, one of "default", "versioned", "timestamped"')
+    .default('buildNamingScheme', 'default')
+    
+    .describe('macCredits', 'MAC ONLY: The path to your credits.html file')
+    .default('macCredits', false)
+    
+    .describe('macIcns', 'MAC ONLY: The path to your ICNS icon file')
+    .default('macIcns', false)
+    
+    .describe('macZip', 'MAC ONLY: Use a app.nw folder instead of ZIP file')
+    .default('macZip', false)
+    .boolean('macZip')
+    
+    .describe('macPlist', 'MAC ONLY: if you supply a string to a Plist file it will use it')
+    .default('macPlist', false)
+    
+    .describe('winIco', 'WINDOWS ONLY: The path to your ICO icon file (requires Windows/Wine)')
+    .default('winIco', null)
+
+
 
 
     .default('quiet', false)
@@ -69,13 +102,19 @@ var options = {
     forceDownload: argv.forceDownload
 };
 
+// Additional CLI options that correspond directly to API options
+for(var k in argv){
+    if(!options[k]){
+        options[k] = argv[k];
+    }
+}
+
 // Check Platform, if we are in run mode
 if(argv.r) {
-    var currentPlatform = detectCurrentPlatform()
+    var currentPlatform = detectCurrentPlatform();
     options.platforms = [ currentPlatform ];
     options.currentPlatform = currentPlatform;
 }
-
 
 // Build App
 var nw = new NwBuilder(options);

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,13 +24,13 @@ function NwBuilder(options) {
         files: null,
         appName: false,
         appVersion: false,
-        platforms: ['win','osx'],
+        platforms: ['win', 'osx'],
         currentPlatform: detectCurrentPlatform(),
         version: 'latest',
         buildDir: './build',
         cacheDir: './cache',
         downloadUrl: 'http://dl.node-webkit.org/',
-        buildType: 'default',
+        buildNamingScheme: 'default',
         forceDownload: false,
         macCredits: false,
         macIcns: false,
@@ -42,6 +42,7 @@ function NwBuilder(options) {
 
     // Assing options
     this.options = _.defaults(options, defaults);
+    this.options.buildNamingScheme = options.buildType || options.buildNamingScheme || defaults.buildNamingScheme;
     this._platforms = platforms;
 
     // Some Option checking
@@ -250,11 +251,11 @@ NwBuilder.prototype.createReleaseFolder = function () {
     var self = this,
         releasePath;
 
-    if (_.isFunction(self.options.buildType)) {
-      releasePath = self.options.buildType.call(self.options);
+    if (_.isFunction(self.options.buildNamingScheme)) {
+      releasePath = self.options.buildNamingScheme.call(self.options);
     } else {
-      // buildTypes
-      switch(self.options.buildType) {
+      // build naming schemes
+      switch(self.options.buildNamingScheme) {
           case 'timestamped':
               releasePath = self.options.appName + ' - ' + Math.round(Date.now() / 1000).toString();
           break;


### PR DESCRIPTION
Fixes #67 Add additional CLI options that correspond directly to API options, such as `--appName`

This also deprecates `buildType` in favor of `buildNamingScheme`, which is, I think, a much better name. It should be backwards-compatible.

I have tested this with a few options a bit on windows, but some of these options are mac-only or not very interesting to test (cacheDir). It seems to work pretty well.

What do you think about the descriptions? I mostly took the first sentences from the README.