### PR TITLE
Fix copyFile method

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -83,33 +83,34 @@ module.exports = {
     },
     copyFile: function (src, dest, _event) {
         var copy = function(resolve, reject, retryCount){
-            var onFailure = function(err){
-                if(retryCount > 2){
-                    return reject(err);
-                }
-                else {
-                    setTimeout(function(){
-                        copy(resolve, reject, retryCount + 1);
-                    }, 200);
-                }
-            };
 
             var stats = fs.lstatSync(src);
             fs.copy(src, dest, function (err) {
                 if(err) return reject(err);
 
-                fs.exists(dest, function(exists){
+                var retryCount = 0;
+                var existsCallback = function(exists){
                     if(exists){
                         fs.chmod(dest, stats.mode, function(err){
                             // ignore error
-                            _event.emit('log', 'chmod ' + stats.mode + ' on ' + dest + ' failed after copying, ignoring');
+                            if (err) {
+                                _event.emit('log', 'chmod ' + stats.mode + ' on ' + dest + ' failed after copying, ignoring');
+                            }
+                            
                             resolve();
                         });
+                    } else if (retryCount++ < 2) {
+                        // This is antipattern!!!
+                        // Callback should be called when the copy is finished!!!!
+                        setTimeout(function(){
+                            fs.exists(dest, existsCallback);
+                        }, 1000);
+                    } else {
+                        reject(new Error("Copied file (" + dest + ") doesn't exist in destination after copying"));
                     }
-                    else {
-                        onFailure(new Error("Copied file (" + dest + ") doesn't exist in destination after copying"));
-                    }
-                });
+                }
+
+                fs.exists(dest, existsCallback);
             });
         };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -82,8 +82,7 @@ module.exports = {
         return absolutePath.split(path.sep).length;
     },
     copyFile: function (src, dest, _event) {
-        var copy = function(resolve, reject, retryCount){
-
+        return new Promise(function(resolve, reject) {
             var stats = fs.lstatSync(src);
             fs.copy(src, dest, function (err) {
                 if(err) return reject(err);
@@ -112,10 +111,6 @@ module.exports = {
 
                 fs.exists(dest, existsCallback);
             });
-        };
-
-        return new Promise(function(resolve, reject) {
-            copy(resolve, reject, 0);
         });
     },
     mergeFiles: function (app, zipfile, chmod) {


### PR DESCRIPTION
When file doesn't exist after copy, DO NOT COPY IT AGAIN. We will only check its existence again.

fixes #147