### PR TITLE
fixed broken osx about screen when copyright not supplied

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -190,8 +190,9 @@ module.exports = {
             obj.CFBundleVersion = parsedParams.version;
             obj.CFBundleShortVersionString = 'Version ' + parsedParams.version;
         }
-        // Read a user defined copyright text or set it to false otherwise
-        obj.NSHumanReadableCopyright = parsedParams.copyright || false;
+        if(parsedParams.copyright) {
+            obj.NSHumanReadableCopyright = parsedParams.copyright;
+        }
 
         return _.merge(obj, custom);
     },
@@ -203,8 +204,7 @@ module.exports = {
             'CFBundleName',
             'CFBundleDisplayName',
             'CFBundleVersion',
-            'CFBundleShortVersionString',
-            'NSHumanReadableCopyright'
+            'CFBundleShortVersionString'
         ].forEach(function(prop) {
                 if(!options.hasOwnProperty(prop)) {
                     throw new Error('Missing macPlist property \'' + prop + '\'');

--- a/test/expected/osx-plist/2.plist
+++ b/test/expected/osx-plist/2.plist
@@ -36,7 +36,5 @@
     <string>222137</string>
     <key>UTExportedTypeDeclarations</key>
     <array/>
-    <key>NSHumanReadableCopyright</key>
-    <false/>
   </dict>
 </plist>


### PR DESCRIPTION
Fun fact: trying to google for issues with "osx about screen" will just give you info *about* osx screens. :disappointed:

Anyway...

If you dont set a copyright, then the "My App" -> "About My App" window in osx will not open on the first click, and on the second click will give you this:

![broken](https://cloud.githubusercontent.com/assets/298742/5738492/c23459ee-9be4-11e4-8a4d-e2ea0ea2ee51.png)
Note the weird version string even if the version number is set.

If you supply the copyright info, then everything works and you get this:
![copyright](https://cloud.githubusercontent.com/assets/298742/5738516/138b2f98-9be5-11e4-8c17-0a9a9c4618d4.png)
Which is all hunky dory.

The problem is caused by `NSHumanReadableCopyright` being set to `false` in the Info.plist if the copyright info isnt supplied to node-webkit-builder. This causes osx to cry as it expects a string. From the [spec](https://developer.apple.com/library/mac/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html):

> NSHumanReadableCopyright (String - OS X). This key contains a string with the copyright notice for the bundle; for example, © 2008, My Company. You can load this string and display it in an About dialog box. This key can be localized by including it in your InfoPlist.strings files. This key replaces the obsolete CFBundleGetInfoString key.

Also note that `NSHumanReadableCopyright` hasnt been marked as "required" or even "recommended", so we dont even need to set that key if nothing is supplied to node-webkit-builder. So this fix just removes the fallback that sets the key to `false`. With this fix, this is what the about screen now looks like if you dont supply copyright info:

![nocopyright](https://cloud.githubusercontent.com/assets/298742/5738669/d5d2c394-9be6-11e4-84b6-09979b687fba.png)
:tada:

/cc @bastimeyer as this fix undoes changes made in #143