### PR TITLE
fixed downloads after move to nwjs.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 > Lets you build your [node-webkit](https://github.com/rogerwang/node-webkit) apps for mac, win and linux via cli. It will download the prebuilt binaries for a newest version, unpacks it, creates a release folder, create the app.nw file for a specified directory and copies the app.nw file where it belongs.
 
+## Warning: NW.js 0.12.0-alpha1 is currently unsupported
+node-webkit was [recently renamed](https://groups.google.com/forum/#!msg/nwjs-general/V1FhvfaFIzQ/720xKVd0jNkJ) to NW.js and we are currently working to support it. Follow [#157](https://github.com/mllrsohn/node-webkit-builder/issues/157) for updates.
 
 ### Installation
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,7 @@ function NwBuilder(options) {
         version: 'latest',
         buildDir: './build',
         cacheDir: './cache',
-        downloadUrl: 'http://dl.node-webkit.org/',
+        downloadUrl: 'http://dl.nwjs.io/',
         buildType: 'default',
         forceDownload: false,
         macCredits: false,


### PR DESCRIPTION
http://node-webkit.org has been moved to http://nwjs.io

Note that this will fix all downloads except for 0.12.0-alpha1 due to the name change.