### PR TITLE
fixed build fail in example. downloading nwbuild version is old.

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "devDependencies": {
     "gulp": "^3.x",
-    "node-webkit-builder": "^0.x"
+    "node-webkit-builder": "^1.x"
   },
   "dependencies": {
     "gulp-util": "^2.2.14"


### PR DESCRIPTION
build fail in example.  error message is "Error: unknown platform win32".
This error is caused by older version of node-webkit-builder.
so fixed package.json.