### PR TITLE
Safely access child process reference created when using run()

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -561,18 +561,18 @@ NwBuilder.prototype.runApp = function () {
 
     self.emit('log', 'Launching App');
     return new Promise(function(resolve, reject) {
-        var p = self._p = spawn(executable, ['--enable-logging', self.options.files.replace(/\*[\/\*]*/,"")].concat(self.options.argv));
+        var nwProcess = self._nwProcess = spawn(executable, ['--enable-logging', self.options.files.replace(/\*[\/\*]*/,"")].concat(self.options.argv));
 
-        p.stdout.on('data', function(data) {
+        nwProcess.stdout.on('data', function(data) {
             self.emit('stdout', data);
         });
 
-        p.stderr.on('data', function(data) {
+        nwProcess.stderr.on('data', function(data) {
             self.emit('stderr', data);
         });
 
-        p.on('close', function(code) {
-            self._p = undefined;
+        nwProcess.on('close', function(code) {
+            self._nwProcess = undefined;
             self.emit('log', 'App exited with code ' + code);
             resolve();
         });
@@ -580,11 +580,11 @@ NwBuilder.prototype.runApp = function () {
 };
 
 NwBuilder.prototype.isAppRunning = function () {
-    return this._p !== undefined;
+    return this._nwProcess !== undefined;
 };
 
 NwBuilder.prototype.getAppProcess = function () {
-    return this._p;
+    return this._nwProcess;
 };
 
 NwBuilder.prototype._forEachPlatform = function (fn) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -561,7 +561,7 @@ NwBuilder.prototype.runApp = function () {
 
     self.emit('log', 'Launching App');
     return new Promise(function(resolve, reject) {
-        var p = spawn(executable, ['--enable-logging', self.options.files.replace(/\*[\/\*]*/,"")].concat(self.options.argv));
+        var p = self._p = spawn(executable, ['--enable-logging', self.options.files.replace(/\*[\/\*]*/,"")].concat(self.options.argv));
 
         p.stdout.on('data', function(data) {
             self.emit('stdout', data);
@@ -572,10 +572,19 @@ NwBuilder.prototype.runApp = function () {
         });
 
         p.on('close', function(code) {
+            self._p = undefined;
             self.emit('log', 'App exited with code ' + code);
             resolve();
         });
     });
+};
+
+NwBuilder.prototype.isAppRunning = function () {
+    return this._p !== undefined;
+};
+
+NwBuilder.prototype.getAppProcess = function () {
+    return this._p;
 };
 
 NwBuilder.prototype._forEachPlatform = function (fn) {


### PR DESCRIPTION
Sometimes you need access to the reference of the child process created when launching nw using run(). This commit attempts to expose it in an orderly manner