### PR TITLE
Fix for overwriting specified mac plist properties

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -241,10 +241,12 @@ module.exports = {
                 });
 
                 // Remove some unwanted properties
-                if(!options.hasOwnProperty('mac_document_types')) {
+                if(!(options.hasOwnProperty('mac_document_types') || options.hasOwnProperty('CFBundleDocumentTypes'))) {
                     info.CFBundleDocumentTypes = [];
                 }
-                info.UTExportedTypeDeclarations = [];
+
+                if(!options.hasOwnProperty('UTExportedTypeDeclarations'))
+                    info.UTExportedTypeDeclarations = [];
 
                 // Write output file
                 return writeFile(plistOutput, plist.build(info));


### PR DESCRIPTION
I had macPlist overrides set to:

```json
{
    "CFBundleDocumentTypes": [{
        "CFBundleTypeExtensions": ["html","htm"],
        "CFBundleTypeIconFile": "nw.icns",
        "CFBundleTypeMIMETypes": ["text/html"],
        "CFBundleTypeName": "HTML dokument",
        "CFBundleTypeOSTypes": ["HTML"],
        "CFBundleTypeRole":"Viewer"
    },{
        "CFBundleTypeExtensions":["xhtml"],
        "CFBundleTypeIconFile":"nw.icns",
        "CFBundleTypeMIMETypes":["text/xhtml"],
        "CFBundleTypeName":"XHTML dokument",
        "CFBundleTypeRole":"Viewer"
    }]
}
```

but in the Info.plist was:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
  <dict>
    <!-- ... -->
    <key>CFBundleDocumentTypes</key>
    <array />
     <!-- ... -->
  </dict>
</plist>
```

now it is correctly:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
  <dict>
    <!-- ... -->
    <key>CFBundleDocumentTypes</key>
    <array>
      <dict>
        <key>CFBundleTypeExtensions</key>
        <array>
          <string>html</string>
          <string>htm</string>
        </array>
        <key>CFBundleTypeIconFile</key>
        <string>nw.icns</string>
        <key>CFBundleTypeMIMETypes</key>
        <array>
          <string>text/html</string>
        </array>
        <key>CFBundleTypeName</key>
        <string>HTML dokument</string>
        <key>CFBundleTypeOSTypes</key>
        <array>
          <string>HTML</string>
        </array>
        <key>CFBundleTypeRole</key>
        <string>Viewer</string>
      </dict>
      <dict>
        <key>CFBundleTypeExtensions</key>
        <array>
          <string>xhtml</string>
        </array>
        <key>CFBundleTypeIconFile</key>
        <string>nw.icns</string>
        <key>CFBundleTypeMIMETypes</key>
        <array>
          <string>text/xhtml</string>
        </array>
        <key>CFBundleTypeName</key>
        <string>XHTML dokument</string>
        <key>CFBundleTypeRole</key>
        <string>Viewer</string>
      </dict>
    </array>
    <!-- ... -->
  </dict>
</plist>
```