### PR TITLE
Update platforms.js

### DIFF
--- a/lib/platforms.js
+++ b/lib/platforms.js
@@ -6,7 +6,8 @@ module.exports = {
         getRunnable: function() { return 'nw.exe'; },
         files: { // First file must be the executable
             '<=0.9.2': ['nw.exe', 'ffmpegsumo.dll', 'icudt.dll', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak'],
-            '>0.9.2': ['nw.exe', 'ffmpegsumo.dll', 'icudtl.dat', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales']
+            '>0.9.2': ['nw.exe', 'ffmpegsumo.dll', 'icudtl.dat', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales'],
+            '>=0.12.0': ['nw.exe', 'ffmpegsumo.dll', 'icudtl.dat', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales', 'd3dcompiler_47.dll', 'pdf.dll']
         },
         versionNameTemplate: 'v${ version }/${ name }-v${ version }-win-ia32.zip'
     },
@@ -15,7 +16,8 @@ module.exports = {
         getRunnable: function() { return 'nw.exe'; },
         files: { // First file must be the executable
             '<=0.9.2': ['nw.exe', 'ffmpegsumo.dll', 'icudt.dll', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales'],
-            '>0.9.2': ['nw.exe', 'ffmpegsumo.dll', 'icudtl.dat', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales']
+            '>0.9.2': ['nw.exe', 'ffmpegsumo.dll', 'icudtl.dat', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales'],
+            '>=0.12.0': ['nw.exe', 'ffmpegsumo.dll', 'icudtl.dat', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales', 'd3dcompiler_47.dll', 'pdf.dll']
         },
         versionNameTemplate: 'v${ version }/${ name }-v${ version }-win-x64.zip'
     },

--- a/lib/platforms.js
+++ b/lib/platforms.js
@@ -55,7 +55,8 @@ module.exports = {
         getRunnable: function() { return 'nw'; },
         files: { // First file must be the executable
             '<=0.9.2': ['nw', 'nw.pak', 'libffmpegsumo.so'],
-            '>0.9.2': ['nw', 'nw.pak', 'libffmpegsumo.so', 'icudtl.dat']
+            '>0.9.2 <=0.10.1': ['nw', 'nw.pak', 'libffmpegsumo.so', 'icudtl.dat'],
+            '>0.10.1':         ['nw', 'nw.pak', 'libffmpegsumo.so', 'icudtl.dat', 'locales']
         },
         versionNameTemplate: 'v${ version }/${ name }-v${ version }-linux-ia32.tar.gz'
     },
@@ -65,7 +66,8 @@ module.exports = {
         getRunnable: function() { return 'nw'; },
         files: { // First file must be the executable
             '<=0.9.2': ['nw', 'nw.pak', 'libffmpegsumo.so'],
-            '>0.9.2': ['nw', 'nw.pak', 'libffmpegsumo.so', 'icudtl.dat']
+            '>0.9.2 <=0.10.1': ['nw', 'nw.pak', 'libffmpegsumo.so', 'icudtl.dat'],
+            '>0.10.1':         ['nw', 'nw.pak', 'libffmpegsumo.so', 'icudtl.dat', 'locales']
         },
         versionNameTemplate: 'v${ version }/${ name }-v${ version }-linux-x64.tar.gz'
     }


### PR DESCRIPTION
In nwjs > 0.12.0 two dll were missing in the final folder. Needed for webgl, etc, in some windows machines.