### PR TITLE
Modified the error message when it fails to download a build.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -235,7 +235,7 @@ NwBuilder.prototype.downloadNodeWebkit = function () {
                 Downloader.downloadAndUnpack(platform.cache, platform.url)
                     .catch(function(err){
                         if(err.statusCode === 404){
-                            self.emit('log', 'ERROR: The version '+self._version.version+' does not have a corresponding build posted at http://dl.node-webkit.org/. Please choose a version from that list.')
+                            self.emit('log', 'ERROR: The version '+self._version.version+' does not have a corresponding build posted at ' + self.options.downloadUrl + '. Please choose a version from that list.')
                         } else {
                             self.emit('log', err.msg)
                         }


### PR DESCRIPTION
I'm getting this error message as per issue #227. I don't know how to fix it at this time but I thought perhaps the URL hadn't been updated from node-webkit.org to nwjs.io. Looking at the code, the URL is correct; only the error message is incorrect so I figured I'd update the error to eliminate some confusion.