### PR TITLE
runApp "appstart" event

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -563,12 +563,19 @@ NwBuilder.prototype.runApp = function () {
     return new Promise(function(resolve, reject) {
         var nwProcess = self._nwProcess = spawn(executable, ['--enable-logging', self.options.files.replace(/\*[\/\*]*/,"")].concat(self.options.argv));
 
+        self.emit('appstart');
+
         nwProcess.stdout.on('data', function(data) {
             self.emit('stdout', data);
         });
 
         nwProcess.stderr.on('data', function(data) {
             self.emit('stderr', data);
+        });
+
+        nwProcess.on('error', function(err) {
+            self.emit('log', 'App launch error: ' + err);
+            reject(err);
         });
 
         nwProcess.on('close', function(code) {


### PR DESCRIPTION
Right now it's impossible to know when the NW.js process is starting after calling `run()`. The promise will be resolved when killing the application, so the promise itself can't be used for getting the NW.js process.
With this change an `appstart` event will be triggered right after spawning the NW.js process. There's also an error callback added, which will reject the promise in case of an error.