### PR TITLE
added pdf.dll to listed files for versions greater than 0.11.5

### DIFF
--- a/lib/platforms.js
+++ b/lib/platforms.js
@@ -6,7 +6,8 @@ module.exports = {
         getRunnable: function() { return 'nw.exe'; },
         files: { // First file must be the executable
             '<=0.9.2': ['nw.exe', 'ffmpegsumo.dll', 'icudt.dll', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak'],
-            '>0.9.2': ['nw.exe', 'ffmpegsumo.dll', 'icudtl.dat', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales']
+            '>0.9.2': ['nw.exe', 'ffmpegsumo.dll', 'icudtl.dat', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales'],
+            '>=0.11.5': ['nw.exe', 'ffmpegsumo.dll', 'icudtl.dat', 'libEGL.dll', 'libGLESv2.dll', 'pdf.dll', 'd3dcompiler_46.dll', 'nw.pak', 'locales']
         },
         versionNameTemplate: 'v${ version }/${ name }-v${ version }-win-ia32.zip'
     },
@@ -15,7 +16,8 @@ module.exports = {
         getRunnable: function() { return 'nw.exe'; },
         files: { // First file must be the executable
             '<=0.9.2': ['nw.exe', 'ffmpegsumo.dll', 'icudt.dll', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales'],
-            '>0.9.2': ['nw.exe', 'ffmpegsumo.dll', 'icudtl.dat', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales']
+            '>0.9.2': ['nw.exe', 'ffmpegsumo.dll', 'icudtl.dat', 'libEGL.dll', 'libGLESv2.dll', 'nw.pak', 'locales'],
+            '>=0.11.5': ['nw.exe', 'ffmpegsumo.dll', 'icudtl.dat', 'libEGL.dll', 'libGLESv2.dll', 'pdf.dll', 'd3dcompiler_46.dll', 'nw.pak', 'locales']
         },
         versionNameTemplate: 'v${ version }/${ name }-v${ version }-win-x64.zip'
     },


### PR DESCRIPTION
```pdf.dll``` is now included in the list of libraries which will make it possible for printing to work again.